### PR TITLE
Codemod to migrate `Ember.$` and `Em.$` to global `$`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/ember-component-jquery.svg?label=npm)](https://www.npmjs.com/package/ember-component-jquery)
 
 
-A codemod for migrating Ember Component code from `this.$()` to `$(this.element)`
+A codemod for migrating Ember Component code from `this.$()` to `$(this.element)` and `Ember.$('.class')` to `$('.class')`;
 
 ## Usage
 
@@ -16,6 +16,7 @@ npx ember-component-jquery this-jquery path/of/files/ or/some**/*glob.js
 ## Transforms
 
 <!--TRANSFORMS_START-->
+* [ember-jquery](transforms/ember-jquery/README.md)
 * [this-jquery](transforms/this-jquery/README.md)
 <!--TRANSFORMS_END-->
 

--- a/helpers/import.js
+++ b/helpers/import.js
@@ -1,0 +1,26 @@
+function insertImportDeclaration(j, code, specifier, source) {
+  let hasjQueryImport = Boolean(
+    j(code).find(j.ImportDeclaration, {
+      source: {
+        value: 'jquery',
+      },
+    }).length
+  );
+
+  if (hasjQueryImport) {
+    return code;
+  }
+
+  return j(code)
+    .find(j.Program)
+    .forEach(path => {
+      let jqueryImport = j.importDeclaration(
+        [j.importDefaultSpecifier(j.identifier(specifier))],
+        j.literal(source)
+      );
+      path.value.body.unshift(jqueryImport);
+    })
+    .toSource({ quote: 'single' });
+}
+
+module.exports = insertImportDeclaration;

--- a/transforms/ember-jquery/README.md
+++ b/transforms/ember-jquery/README.md
@@ -1,0 +1,90 @@
+# ember-jquery
+
+
+## Usage
+
+```
+npx ember-component-jquery ember-jquery path/of/files/ or/some**/*glob.js
+
+# or
+
+yarn global add ember-component-jquery
+ember-component-jquery ember-jquery path/of/files/ or/some**/*glob.js
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [with-import](#with-import)
+* [without-import](#without-import)
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+---
+<a id="with-import">**with-import**</a>
+
+**Input** (<small>[with-import.input.js](transforms/ember-jquery/__testfixtures__/with-import.input.js)</small>):
+```js
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    Em.$('.test').focus();
+    Em.$(this.element).focus();
+    Ember.$('.test').focus();
+    Ember.$(this.element).focus();
+  },
+});
+
+```
+
+**Output** (<small>[with-import.output.js](transforms/ember-jquery/__testfixtures__/with-import.output.js)</small>):
+```js
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    $('.test').focus();
+    $(this.element).focus();
+    $('.test').focus();
+    $(this.element).focus();
+  },
+});
+
+```
+---
+<a id="without-import">**without-import**</a>
+
+**Input** (<small>[without-import.input.js](transforms/ember-jquery/__testfixtures__/without-import.input.js)</small>):
+```js
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    Em.$('.test').focus();
+    Em.$(this.element).focus();
+    Ember.$('.test').focus();
+    Ember.$(this.element).focus();
+  },
+});
+
+```
+
+**Output** (<small>[without-import.output.js](transforms/ember-jquery/__testfixtures__/without-import.output.js)</small>):
+```js
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    $('.test').focus();
+    $(this.element).focus();
+    $('.test').focus();
+    $(this.element).focus();
+  },
+});
+
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/ember-jquery/__testfixtures__/with-import.input.js
+++ b/transforms/ember-jquery/__testfixtures__/with-import.input.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    Em.$('.test').focus();
+    Em.$(this.element).focus();
+    Ember.$('.test').focus();
+    Ember.$(this.element).focus();
+  },
+});

--- a/transforms/ember-jquery/__testfixtures__/with-import.output.js
+++ b/transforms/ember-jquery/__testfixtures__/with-import.output.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    $('.test').focus();
+    $(this.element).focus();
+    $('.test').focus();
+    $(this.element).focus();
+  },
+});

--- a/transforms/ember-jquery/__testfixtures__/without-import.input.js
+++ b/transforms/ember-jquery/__testfixtures__/without-import.input.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    Em.$('.test').focus();
+    Em.$(this.element).focus();
+    Ember.$('.test').focus();
+    Ember.$(this.element).focus();
+  },
+});

--- a/transforms/ember-jquery/__testfixtures__/without-import.output.js
+++ b/transforms/ember-jquery/__testfixtures__/without-import.output.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    $('.test').focus();
+    $(this.element).focus();
+    $('.test').focus();
+    $(this.element).focus();
+  },
+});

--- a/transforms/ember-jquery/index.js
+++ b/transforms/ember-jquery/index.js
@@ -1,0 +1,27 @@
+const { getParser } = require('codemod-cli').jscodeshift;
+const insertImportDeclaration = require('../../helpers/import');
+
+module.exports = function transformer(file, api) {
+  const j = getParser(api);
+
+  let needsjQueryImport = false;
+
+  let code = j(file.source)
+    .find(j.CallExpression, node => {
+      let id = node.callee.object && node.callee.object.name;
+      let prop = node.callee.property && node.callee.property.name;
+
+      return ['Ember', 'Em'].includes(id) && prop == '$';
+    })
+    .forEach(path => {
+      j(path).replaceWith(j.callExpression(j.identifier('$'), path.value.arguments));
+      needsjQueryImport = true;
+    })
+    .toSource();
+
+  if (needsjQueryImport) {
+    code = insertImportDeclaration(j, code, '$', 'jquery');
+  }
+
+  return code;
+};

--- a/transforms/ember-jquery/test.js
+++ b/transforms/ember-jquery/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  type: 'jscodeshift',
+  name: 'ember-jquery',
+});


### PR DESCRIPTION
Codemod to migrate `Ember.$` and `Em.$` to global `$`

#### Before
```
export default Component.extend({
  didInsertElement() {
    Em.$('.test').focus();
    Em.$(this.element).focus();
    Ember.$('.test').focus();
    Ember.$(this.element).focus();
  },
});
```

#### After
```
export default Component.extend({
  didInsertElement() {
    $('.test').focus();
    $(this.element).focus();
    $('.test').focus();
    $(this.element).focus();
  },
});
```